### PR TITLE
어드민에서는 쿠키를 사용하도록 개발

### DIFF
--- a/src/main/java/teamseven/echoeco/config/auth/SecurityConfig.java
+++ b/src/main/java/teamseven/echoeco/config/auth/SecurityConfig.java
@@ -15,10 +15,8 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
-import teamseven.echoeco.config.jwt.CustomSuccessHandler;
-import teamseven.echoeco.config.jwt.JwtExceptionHandlerFilter;
-import teamseven.echoeco.config.jwt.JwtFilter;
-import teamseven.echoeco.config.jwt.JwtUtil;
+import teamseven.echoeco.config.jwt.*;
+import teamseven.echoeco.user.domain.Role;
 import teamseven.echoeco.user.service.CustomOAuth2UserService;
 
 @Configuration
@@ -38,7 +36,7 @@ public class SecurityConfig
                 .requestMatchers(PathRequest.toStaticResources().atCommonLocations())
                 // 필터(로그인 인증) 없이 사용하는 url 추가 필요
                 // /token/init 은 삭제 X
-                .requestMatchers("/vendor/**","/error", "/favicon.ico", "/user/login/**", "/item/list", "/", "/admin/**", "/character/list", "/user/token/**", "/token/init");
+                .requestMatchers("/static/**", "/vendor/**","/error", "/favicon.ico", "/user/login/**", "/item/list", "/", "/character/list", "/user/token/**", "/token/init");
     }
 
     @Bean
@@ -67,12 +65,12 @@ public class SecurityConfig
 //                .headers(headerConfig -> headerConfig.frameOptions(
 //                        FrameOptionsConfig::disable // X-Frame-Options 비활성화
 //                ))
-                .sessionManagement(c ->
-                        c.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용하지 않음
+//                .sessionManagement(c ->
+//                        c.sessionCreationPolicy(SessionCreationPolicy.STATELESS)) // 세션 사용하지 않음
 
                 .authorizeHttpRequests((auth) ->auth
                         .requestMatchers("/", "/user/login", "/file/**",
-                                "/admin/**", "/user/**"  // 임시로 permitAll 로 열어둠. 변경필요함.
+                                 "/user/**"  // 임시로 permitAll 로 열어둠. 변경필요함.
                         ).permitAll()
                 )
                 .authorizeHttpRequests((auth) -> auth.requestMatchers(
@@ -84,8 +82,8 @@ public class SecurityConfig
                 )
 
                 // 권한 설정 주석처리. 변경필요.
-                //.authorizeHttpRequests((authorizeRequests) -> authorizeRequests
-                //       .requestMatchers("/admin/**").hasRole(Role.ADMIN.name()))
+                .authorizeHttpRequests((authorizeRequests) -> authorizeRequests
+                       .requestMatchers("/admin/**").hasRole(Role.ADMIN.name()))
                 //.authorizeHttpRequests((authorizeRequests) -> authorizeRequests
                 //        .requestMatchers("").hasRole(Role.USER.name()))
                 .logout((logoutConfig) -> logoutConfig.logoutSuccessUrl("/")
@@ -100,6 +98,7 @@ public class SecurityConfig
                         .successHandler(customSuccessHandler)
                 )
                 .addFilterBefore(new JwtFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(new JwtCookieFilter(jwtUtil), UsernamePasswordAuthenticationFilter.class)
                 .addFilterBefore(new JwtExceptionHandlerFilter(), JwtFilter.class)
 // ToDo: 배포시 아래 주석 삭제 필요.
      //           .exceptionHandling(ex -> ex.accessDeniedHandler((request, response, accessDeniedException) -> {

--- a/src/main/java/teamseven/echoeco/config/jwt/JwtCookieFilter.java
+++ b/src/main/java/teamseven/echoeco/config/jwt/JwtCookieFilter.java
@@ -1,0 +1,62 @@
+package teamseven.echoeco.config.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.web.filter.OncePerRequestFilter;
+import teamseven.echoeco.user.domain.Dto.UserDto;
+import teamseven.echoeco.user.domain.OAuth2.CustomOauth2User;
+import teamseven.echoeco.user.domain.Role;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtCookieFilter extends OncePerRequestFilter {
+    private final JwtUtil jwtUtil;
+    public static final String TOKEN_NAME = "Authorization";
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String token = getJwtFromCookie(request);
+
+        if (token != null && jwtUtil.validateToken(token)) {
+            String name = jwtUtil.getName(token);
+            String email = jwtUtil.getEmail(token);
+            Role role = jwtUtil.getRole(token);
+
+            request.setAttribute("userName", name);
+
+            UserDto userDTO = new UserDto();
+            userDTO.setName(name);
+            userDTO.setRole(role);
+            userDTO.setEmail(email);
+
+            CustomOauth2User oAuth2User = new CustomOauth2User(userDTO);
+            // 스프링 시큐리티 인증 토큰 생성
+            Authentication authToken = new UsernamePasswordAuthenticationToken(oAuth2User, null,
+                    oAuth2User.getAuthorities());
+            // 세션에 저장
+            SecurityContextHolder.getContext().setAuthentication(authToken);
+        }
+
+        filterChain.doFilter(request, response);
+    }
+
+    private String getJwtFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (TOKEN_NAME.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/teamseven/echoeco/config/jwt/JwtFilter.java
+++ b/src/main/java/teamseven/echoeco/config/jwt/JwtFilter.java
@@ -89,4 +89,9 @@ public class JwtFilter extends OncePerRequestFilter {
             filterChain.doFilter(request, response);
         }
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        return request.getRequestURL().toString().contains("/admin");
+    }
 }

--- a/src/main/java/teamseven/echoeco/config/jwt/JwtUtil.java
+++ b/src/main/java/teamseven/echoeco/config/jwt/JwtUtil.java
@@ -64,5 +64,17 @@ public class JwtUtil {
                 .compact();
     }
 
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().verifyWith(secretKey).build().parseSignedClaims(token);
+            return true;
+        } catch (ExpiredJwtException e) {
+            System.out.println("Token expired");
+            return false;
+        } catch (Exception e) {
+            System.out.println("Token invalid");
+            return false;
+        }
+    }
 
 }

--- a/src/main/java/teamseven/echoeco/login/controller/LoginController.java
+++ b/src/main/java/teamseven/echoeco/login/controller/LoginController.java
@@ -1,8 +1,11 @@
 package teamseven.echoeco.login.controller;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @RequiredArgsConstructor
 @Controller
@@ -19,7 +22,17 @@ public class LoginController {
     }
 
     @GetMapping("/token/init")
-    public String tokenInit() {
+    public String tokenInit(@RequestParam(name = "token") String jwtToken,
+                            HttpServletResponse response) {
+        Cookie cookie = new Cookie("Authorization", jwtToken);
+        cookie.setHttpOnly(true);  // 자바스크립트에서 접근 불가
+//        cookie.setSecure(true);  // HTTPS에서만 전송
+//        cookie.setDomain(".abc.com");
+        cookie.setPath("/admin");
+        cookie.setMaxAge(24 * 60 * 60);  // 24 시간
+
+        response.addCookie(cookie);
+
         return "login/tokenInit";
     }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

fix-92

## 📝작업 내용

어드민에서 Authorization 을 쿠키에 넣어서 사용하도록 수정

핵심 코드:

```java
if (userInfo.getRole() == Role.ADMIN) {
    response.sendRedirect(adminPageDomain + "/token/init?token=" + token);
} else {
    response.sendRedirect(frontServerDomain + "/loginwait?useremail=" + email);
}

// controller
@GetMapping("/token/init")
public String tokenInit(@RequestParam(name = "token") String jwtToken,
                        HttpServletResponse response) {
    Cookie cookie = new Cookie("Authorization", jwtToken);
    cookie.setHttpOnly(true);  // 자바스크립트에서 접근 불가
    cookie.setPath("/admin");
    cookie.setMaxAge(24 * 60 * 60);  // 24 시간

    response.addCookie(cookie);

    return "login/tokenInit";
}

//js
window.location.href = '/admin';
```

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
